### PR TITLE
Removing unused Registry volume

### DIFF
--- a/files/setup_bastian.yaml
+++ b/files/setup_bastian.yaml
@@ -8,14 +8,12 @@
     haproxy_vip: __haproxy_vip__
     domainSuffix: __domain_suffix__
     localDomainSuffix: __local_domain_suffix__
-    registryVolume: __registry_volume__
     openstackOpenshiftPassword: __openshift_openstack_password__
     openstackOpenshiftUsername: __openshift_openstack_username__
     osAuthUrl: __openstack_auth_url__
     osTenantId: __openstack_tenant_id__
     osTenantName: __openstack_tenant_name__
     osRegion: __openstack_region__
-    registryVolumeSize: __registry_volume_size__
     s3accesskey: __s3accesskey__
     s3secretkey: __s3secretkey__
     s3regionendpoint: __s3regionendpoint__
@@ -70,14 +68,12 @@
           {% endfor %}
           haproxy_vip: {{ haproxy_vip }}
           domainSuffix: {{ domainSuffix }}
-          registryVolume: {{ registryVolume }}
           openstackOpenshiftPassword: {{ openstackOpenshiftPassword }}
           openstackOpenshiftUsername: {{ openstackOpenshiftUsername }}
           osAuthUrl: {{ osAuthUrl }}
           osTenantId: {{ osTenantId }}
           osTenantName: {{ osTenantName }}
           osRegion: {{ osRegion }}
-          registryVolumeSize: {{ registryVolumeSize }}
           s3accesskey: {{ s3accesskey }}
           s3secretkey: {{ s3secretkey  }} 
           s3regionendpoint: {{ s3regionendpoint }}

--- a/openshift-template.yaml
+++ b/openshift-template.yaml
@@ -73,10 +73,6 @@ parameters:
     type: comma_delimited_list
     description: ports to open for external access to haproxy servers
     default: "80,443,8443"
-  registry_volume_size:
-    type: string
-    description: Size of the OpenStack volume that backs the OpenShift registry
-    default: 100
   openshift_openstack_username:
     type: string
     description: OpenShift username for cinder integration
@@ -358,14 +354,12 @@ resources:
             __time__: { get_param: time }
             __haproxy_vip__: { get_attr: [ haproxy_port, fixed_ips, 0, ip_address ] }
             __domain_suffix__: { get_param: domain_suffix }
-            __registry_volume__: { get_resource: openshift_registry_volume }
             __openshift_openstack_username__: { get_param: openshift_openstack_username }
             __openshift_openstack_password__: { get_param: openshift_openstack_password }
             __openstack_auth_url__: { get_param: os_auth_url }
             __openstack_tenant_id__: { get_param: os_tenant_id }
             __openstack_tenant_name__: { get_param: os_tenant_name }
             __openstack_region__: { get_param: os_region }
-            __registry_volume_size__: { get_param: registry_volume_size }
             __s3accesskey__: { get_param: s3_access_key }
             __s3secretkey__: { get_param: s3_secret_key }
             __s3regionendpoint__: { get_param: s3_region_endpoint  }
@@ -384,14 +378,6 @@ resources:
         get_resource: setup_host_file
       server:
         get_resource: bastion_host
-
-  openshift_registry_volume:
-    type: OS::Cinder::Volume
-    properties:
-      name: openshift_registry_volume
-      read_only: false
-      size: { get_param: registry_volume_size }
-      volume_type: TIER2
 
 outputs:
   bastion_ip:


### PR DESCRIPTION
Registry volume is no longer needed since we pushed it to use s3. This cleans up that code and ensures no unused volumes are left floating around.