### PR TITLE
Removed bash multinetwork parameter passthrough to HEAT in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -49,7 +49,6 @@ function deployHeatStack() {
   openstack stack create -f yaml -t openshift.yaml openshift-${OS_TENANT_NAME} \
     -e rhel_reg_creds.yaml \
     -e environment.yaml \
-    --parameter multinetwork="$multinetwork" \
     --parameter time="$(date)" \
     --parameter os_auth_url="${OS_AUTH_URL}" \
     --parameter os_tenant_id="${OS_TENANT_ID}" \


### PR DESCRIPTION
Removed bash multinetwork parameter passthrough to HEAT as already specified in environment.yaml

Fixes #61