### PR TITLE
Feature/redhat route

### DIFF
--- a/setup-heat-templates.yaml
+++ b/setup-heat-templates.yaml
@@ -58,6 +58,8 @@
                 route: 51.179.220.66/32
               - gateway: 10.2.1.1
                 route: 51.179.217.10/32
+              - gateway: 10.2.1.1
+                route: 104.82.86.120
           net2_routes:
             type: json
             description: Extra routes needed for all net2 servers (e.g. Satellite)

--- a/setup-heat-templates.yaml
+++ b/setup-heat-templates.yaml
@@ -59,7 +59,7 @@
               - gateway: 10.2.1.1
                 route: 51.179.217.10/32
               - gateway: 10.2.1.1
-                route: 104.82.86.120
+                route: 104.82.86.120/32
           net2_routes:
             type: json
             description: Extra routes needed for all net2 servers (e.g. Satellite)


### PR DESCRIPTION
Adding a new route for 104.82.86.120IP for access.redhat.com as have had multiple failures on net2 deploys where it resolves to this IP