### PR TITLE
added dependancy to extra_gateway_dataplane

### DIFF
--- a/setup-heat-templates.yaml
+++ b/setup-heat-templates.yaml
@@ -303,7 +303,7 @@
 
           extra_gateway_dataplane:
             type: OS::Heat::Stack
-            depends_on: [ extra_gateway ]
+            depends_on: [ extra_gateway, extra_gateway_floating_ip ]
             properties:
               template: { get_file: floatingip.yaml }
               parameters:


### PR DESCRIPTION
To ensure floating IP is always created before the attempt to associate it to a neutron port