### PR TITLE
Resolve Atomic nodes being unable to register with Satellite post-upgrade

### DIFF
--- a/server_atomic.yaml
+++ b/server_atomic.yaml
@@ -73,7 +73,7 @@ resources:
             __satellite_fqdn__: { get_param: satellite_fqdn }
             __satellite_deploy__: { get_param: satellite_deploy }                  
           template: |
-            #!/bin/bash -ex
+            #!/bin/bash -x
              cd /home/cloud-user
              if [[ "__satellite_deploy__" = True ]] 
              then


### PR DESCRIPTION
Due to katello-rhsm-consumer script modifications