### PR TITLE
Open kubecontroller port

### DIFF
--- a/security_groups.yaml
+++ b/security_groups.yaml
@@ -441,7 +441,7 @@ resources:
           remote_group_id: { get_resource: all_nodes_egress_secgroup }
           protocol: tcp
           port_range_min: 8443
-          port_range_max: 8443
+          port_range_max: 8444
         - direction: ingress
           ethertype: IPv4
           remote_mode: remote_group_id


### PR DESCRIPTION
Port 8444 needs to be opened in order for the kube controllers to communicate correctly and not generate alerts in alertmanager