### PR TITLE
Move port 80 on controlplane to its own security group

### DIFF
--- a/security_groups.yaml
+++ b/security_groups.yaml
@@ -166,6 +166,17 @@ resources:
             port_range_min: <%port%>
             port_range_max: <%port%>
 
+  certbot_controlplane_secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: certbot_controlplane_sg
+      rules:
+          - direction: ingress
+            protocol: tcp
+            remote_ip_prefix: 0.0.0.0/0
+            port_range_min: 80
+            port_range_max: 80
+
   proxy_controlplane_secgroup:
     type: OS::Neutron::SecurityGroup
     properties:
@@ -522,7 +533,6 @@ outputs:
   vrrp_nodes_security_group:
     description: VRRP access between tenant and net2 nodes
     value: { get_resource: vrrp_nodes_secgroup }
-
   bastion_external_security_group:
     description: Bastion external security group
     value: { get_resource: bastion_external_secgroup }
@@ -580,3 +590,6 @@ outputs:
   proxy_security_group:
     description: Net2 LB VRRP security group
     value: { get_resource: proxy_controlplane_secgroup }
+  certbot_security_group:
+    description: Security group allowing http-01 challenge
+    value: { get_resource: certbot_controlplane_secgroup }

--- a/security_groups.yaml
+++ b/security_groups.yaml
@@ -166,10 +166,10 @@ resources:
             port_range_min: <%port%>
             port_range_max: <%port%>
 
-  certbot_controlplane_secgroup:
+  controlplane_certbot_secgroup:
     type: OS::Neutron::SecurityGroup
     properties:
-      name: certbot_controlplane_sg
+      name: controlplane_certbot_sg
       rules:
           - direction: ingress
             protocol: tcp
@@ -590,6 +590,6 @@ outputs:
   proxy_security_group:
     description: Net2 LB VRRP security group
     value: { get_resource: proxy_controlplane_secgroup }
-  certbot_security_group:
+  controlplane_certbot_security_group:
     description: Security group allowing http-01 challenge
-    value: { get_resource: certbot_controlplane_secgroup }
+    value: { get_resource: controlplane_certbot_secgroup }

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -168,7 +168,7 @@ resources:
     properties:
       template: { get_file: security_groups.yaml }
       parameters:
-        control_plane_ports: "80,443,8443"
+        control_plane_ports: "443,8443"
         data_plane_ports: "80,443"
         control_plane_sources: { get_param: control_plane_allowed_sources }
         data_plane_sources: { get_param: data_plane_allowed_sources }

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -219,6 +219,7 @@ resources:
           - { get_attr: [ security_groups, outputs, dns_forwarder_security_group ] }
           - { get_attr: [ security_groups, outputs, vrrp_controlplane_security_group ] }
           - { get_attr: [ security_groups, outputs, proxy_security_group ] }
+          - { get_attr: [ security_groups, outputs, certbot_security_group ] }
 
   master_nodes_deployment:
     type: OS::Heat::Stack

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -219,7 +219,7 @@ resources:
           - { get_attr: [ security_groups, outputs, dns_forwarder_security_group ] }
           - { get_attr: [ security_groups, outputs, vrrp_controlplane_security_group ] }
           - { get_attr: [ security_groups, outputs, proxy_security_group ] }
-          - { get_attr: [ security_groups, outputs, certbot_security_group ] }
+          - { get_attr: [ security_groups, outputs, controlplane_certbot_security_group ] }
 
   master_nodes_deployment:
     type: OS::Heat::Stack


### PR DESCRIPTION
This allows us to build an environment specifying a controlplane whitelist removing the need to perform a stack update post-deployment. This also reduces the number of rules that are added to the controlplane_sg by splitting out the port 80 rule to its own sg. This could be removed post-deployment to enhance security although only certbot listens on this port when renewing certificates.