### PR TITLE
Add monitoring_sg, bash script to populate monitoring_allowed_sources

### DIFF
--- a/get_pingdom_ips.sh
+++ b/get_pingdom_ips.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Quick script to retrieve the Pingdom list of EU monitoring IPs and format it for environment.yaml
+# Output can be appended to the end of environment.yaml:
+#   ./get_pingdom_ips.sh >> environment.yaml
+IPLIST=`curl https://help.pingdom.com/hc/en-us/article_attachments/360003037257/EU_IP_list.txt | grep -v ":"`
+LAST=`echo $IPLIST | awk '{ print $NF }'`
+
+echo ""
+echo -n "  monitoring_allowed_sources: [ "
+for IP in $IPLIST; do
+    echo -n "\"${IP}/32\""
+    if [ $IP != "$LAST" ]; then
+        echo -n ", "
+    else
+        echo -n " "
+    fi
+done
+echo ']'

--- a/security_groups.yaml
+++ b/security_groups.yaml
@@ -20,6 +20,9 @@ parameters:
   control_plane_sources:
     type: comma_delimited_list
     description: ip addresses that inbound connectivity can come from
+  monitoring_sources:
+    type: comma_delimited_list
+    description: ip addresses that inbound connectivity for monitoring
   data_plane_sources:
     type: comma_delimited_list
     description: ip addresses that inbound connectivity can come from
@@ -165,6 +168,23 @@ resources:
         repeat:
           for_each:
             <%sourceip%>: { get_param: control_plane_sources }
+            <%port%>: { get_param: control_plane_ports }
+          template:
+            protocol: tcp
+            direction: ingress
+            remote_ip_prefix: <%sourceip%>
+            port_range_min: <%port%>
+            port_range_max: <%port%>
+
+
+  monitoring_secgroup:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name: monitoring_sg
+      rules:
+        repeat:
+          for_each:
+            <%sourceip%>: { get_param: monitoring_sources }
             <%port%>: { get_param: control_plane_ports }
           template:
             protocol: tcp
@@ -549,6 +569,9 @@ outputs:
   control_plane_security_group:
     description: Security group controlling access to the control plane
     value: { get_resource: control_plane_secgroup }
+  monitoring_security_group:
+    description: Security group controlling access to the control plane for monitoring
+    value: { get_resource: monitoring_secgroup }
   data_plane_security_group:
     description: Security group controlling access to the data plane
     value: { get_resource: data_plane_secgroup }

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -117,6 +117,10 @@ parameters:
     type: comma_delimited_list
     description: ip addresses that inbound connectivity can come from
     default: [ "0.0.0.0/0" ]
+  monitoring_allowed_sources:
+    type: comma_delimited_list
+    description: ip addresses that inbound connectivity can come from for monitoring
+    default: [ "0.0.0.0/32" ]
   data_plane_allowed_sources:
     type: comma_delimited_list
     description: ip addresses that inbound connectivity can come from
@@ -177,6 +181,7 @@ resources:
         control_plane_sources: { get_param: control_plane_allowed_sources }
         data_plane_sources: { get_param: data_plane_allowed_sources }
         bastion_sources: { get_param: bastion_allowed_sources }
+        monitoring_sources: { get_param: monitoring_allowed_sources }
 
   external_services_infra:
     type: OS::Heat::ResourceGroup
@@ -220,6 +225,7 @@ resources:
           - { get_attr: [ security_groups, outputs, all_internet_egress_security_group ] }
           - { get_attr: [ security_groups, outputs, bastion_internal_ssh_security_group ] }
           - { get_attr: [ security_groups, outputs, control_plane_security_group ] }
+          - { get_attr: [ security_groups, outputs, monitoring_security_group ] }
           - { get_attr: [ security_groups, outputs, dns_internet_security_group ] }
           - { get_attr: [ security_groups, outputs, dns_forwarder_security_group ] }
           - { get_attr: [ security_groups, outputs, vrrp_controlplane_security_group ] }
@@ -485,6 +491,9 @@ outputs:
   control_plane_whitelist:
     description: whitelisted addresses for control plane access
     value: { get_param: control_plane_allowed_sources }
+  monitoring_whitelist:
+    description: whitelisted addresses for monitoring access
+    value: { get_param: monitoring_allowed_sources }
   data_plane_whitelist:
     description: whitelisted addresses for data plane access
     value: { get_param: data_plane_allowed_sources }

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -383,6 +383,7 @@ resources:
           - { get_attr: [ security_groups, outputs, all_internet_egress_security_group ] }
           - { get_attr: [ security_groups, outputs, bastion_internal_ssh_security_group ] }
           - { get_attr: [ security_groups, outputs, data_plane_security_group ] }
+          - { get_attr: [ security_groups, outputs, monitoring_security_group ] }            
           - { get_attr: [ security_groups, outputs, vrrp_dataplane_security_group ] }
 
   bastion_deployment:


### PR DESCRIPTION
Added monitoring security group for CNAP-940

monitoring_allowed_sources defaults to 0.0.0.0/**32** (which allows nothing)

bash script get_pingdom_ips.sh pulls the known list of EU pingdom IPs. Since this URL is possibly ephemeral (attachment to a blog post), this needs to be ran manually - but its output is formatted so it can be appended to the environment file:

```./get_pingdom_ips.sh >> environment.yaml```

Hopefully, after I've investigated Pingdom API, I can update the script to pull the list of monitoring IPs from API...

Testing in 3.11 heat deploy.