### PR TITLE
Reworking of portworx heat

### DIFF
--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -46,7 +46,8 @@
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      insertafter: "allocation_pools:"
+      #insertafter: "allocation_pools:"
+      insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
       marker: "        # ANSIBLE MANAGED BLOCK - parameters for portworx deployment"
       block: |2
                 # deploy portworx?
@@ -74,26 +75,28 @@
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      insertafter: "purpose_ident: tenant-{{ item }}"
+      #insertafter: "purpose_ident: tenant-{{ item }}"
+      insertafter: "# add-portworx.yaml inserts {{ item }} tenant worker storage networks here"
       marker: "        # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters - worker-{{ item }}"
       block: |2
                 extra_volumes: { get_param: deploy_portworx_storage }
                 storage_management_network: { get_attr: [internal_network, outputs, storage_management_network] }
                 storage_data_network: { get_attr: [internal_network, outputs, storage_data_network] }
-    loop: [ s, m, l ]
+    loop: [ small, medium, large ]
     when: deploy_portworx_storage|bool
 
   - name: add storage networks parameters Net2
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      insertafter: "purpose_ident: {{ purpose_ident }}-{{ item }}"
+      #insertafter: "purpose_ident: {{ purpose_ident }}-{{ item }}"
+      insertafter: "# add-portworx.yaml inserts {{ item }} net2 worker storage networks here"
       marker: "        # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters Net2 - {{ purpose_ident }}-{{ item }}"
       block: |2
                 extra_volumes: { get_param: deploy_portworx_storage }
                 storage_management_network: { get_attr: [internal_network, outputs, storage_management_network] }
                 storage_data_network: { get_attr: [internal_network, outputs, storage_data_network] }
-    loop: [ s, m, l ]
+    loop: [ small, medium, large ]
     when: deploy_portworx_storage|bool and multinetwork|bool
 
   - name: specify pwx server_atomic template
@@ -108,20 +111,21 @@
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      insertbefore: "resources:"
+      #insertbefore: "resources:"
+      insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters"
       block: |2
           deploy_storage_networks:
             type: boolean
             default: false
-        
     when: deploy_portworx_storage|bool
 
   - name: add storage networks
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      insertbefore: "outputs:"
+      #insertbefore: "outputs:"
+      insertafter: "# add-portworx.yaml inserts storage_networks resources here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portworx_networks_resources"
       block: |2
           storage_management_network:
@@ -159,27 +163,30 @@
               ip_version: 4
               gateway_ip: ""
               dns_nameservers: []
-      
-    when: deploy_portworx_storage|bool
-
-  - name: add storage networks
-    blockinfile:
-      dest: network_pwx.yaml
-      backup: yes
-      insertbefore: "outputs:"
-      marker: "# ANSIBLE MANAGED BLOCK - add_portworx_networks_conditions"
-      block: |2
         conditions:
           deploy_storage_networks:
             get_param: deploy_storage_networks
-      
     when: deploy_portworx_storage|bool
+
+    #  - name: add storage networks
+    #    blockinfile:
+    #      dest: network_pwx.yaml
+    #      backup: yes
+    #      insertbefore: "outputs:"
+    #      marker: "# ANSIBLE MANAGED BLOCK - add_portworx_networks_conditions"
+    #      block: |2
+    #        conditions:
+    #          deploy_storage_networks:
+    #            get_param: deploy_storage_networks
+    #      
+    #    when: deploy_portworx_storage|bool
 
   - name: add storage networks outputs
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      insertafter: "outputs:"
+      #insertafter: "outputs:"
+      insertafter: "# add-portworx.yaml inserts storage_networks outputs here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portwox_networks_outputs"
       block: |2
           storage_data_network: 
@@ -194,7 +201,8 @@
     blockinfile:
       dest: node_group_pwx.yaml
       backup: yes
-      insertbefore: "resources:"
+      #insertbefore: "resources:"
+      insertafter: "# add-portworx.yaml inserts network and volume parameters here"
       marker: "  # ANSIBLE MANAGED BLOCK - add parameters to node_group_pwx.yaml"
       block: |2
           extra_volumes:
@@ -207,14 +215,14 @@
           storage_data_network:
             type: string
             description: Network for storage data traffic
-        
     when: deploy_portworx_storage|bool
 
   - name: node_group_resources
     blockinfile:
       dest: node_group_pwx.yaml
       backup: yes
-      insertafter: "server_group: { get_param: server_group }"
+      #insertafter: "server_group: { get_param: server_group }"
+      insertafter: "# add-portworx.yaml inserts server group parameters here"
       marker: "          # ANSIBLE MANAGED BLOCK - add properties to node_group server resources"
       block: |2
                   extra_volumes: { get_param: extra_volumes }
@@ -227,7 +235,8 @@
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      insertbefore: "resources:"
+      #insertbefore: "resources:"
+      insertafter: "# add-portworx.yaml inserts atomic network and volume parameters here"
       marker: "  # ANSIBLE MANAGED BLOCK - add parameters to server_atomic_pwx.yaml"
       block: |2
           extra_volumes:
@@ -240,14 +249,14 @@
           storage_data_network:
             type: string
             description: Network for storage data traffic
-        
     when: deploy_portworx_storage|bool
 
   - name: server_atomic resources
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      insertafter: "- port: { get_resource: port }"
+      #insertafter: "- port: { get_resource: port }"
+      insertafter: "# add-portworx.yaml inserts server_atomic network resources here"
       marker: "        # ANSIBLE MANAGED BLOCK - add properties to server_atomic resources"
       block: |2
                 - network: { get_param: storage_management_network }
@@ -258,10 +267,10 @@
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      insertbefore: "outputs:"
+      #insertbefore: "outputs:"
+      insertafter: "# add-portworx.yaml inserts server_atomic volumes here"
       marker: "  # ANSIBLE MANAGED BLOCK - add properties to server_atomic resources"
       block: |2
-
           portworx_vol1:
             type: OS::Cinder::Volume
             condition: deploy_extra_volumes
@@ -283,15 +292,6 @@
               instance_uuid: { get_resource: server }
               mountpoint: /dev/vdc
               volume_id: { get_resource: portworx_vol1 }
-    when: deploy_portworx_storage|bool
-
-  - name: server_atomic storage resources
-    blockinfile:
-      dest: server_atomic_pwx.yaml
-      backup: yes
-      insertbefore: "outputs:"
-      marker: "# ANSIBLE MANAGED BLOCK - add properties to server_atomic conditions"
-      block: |2
         conditions:
           not_infra:
             not:
@@ -308,10 +308,49 @@
             - deploy_volumes
     when: deploy_portworx_storage|bool
 
-  - name: Change medium worker size for net2
+    #  - name: server_atomic storage resources
+    #    blockinfile:
+    #      dest: server_atomic_pwx.yaml
+    #      backup: yes
+    #      insertbefore: "outputs:"
+    #      marker: "# ANSIBLE MANAGED BLOCK - add properties to server_atomic conditions"
+    #      block: |2
+    #        conditions:
+    #          not_infra:
+    #            not:
+    #              equals:
+    #              - get_param: purpose_ident
+    #              - infra
+    #          deploy_volumes:
+    #            equals:
+    #            - get_param: extra_volumes
+    #            - true
+    #          deploy_extra_volumes:
+    #            and:
+    #            - not_infra
+    #            - deploy_volumes
+    #    when: deploy_portworx_storage|bool
+
+  - name: Change small worker size
     replace:
       path: openshift.yaml
-      regexp: 'ocp.m1.large'
+      regexp: 'ocp.t1.xxlarge # add-portworx.yaml replaces this with pwx.t1.xxlarge'
+      replace: 'pwx.t1.xxlarge'
+      backup: yes
+    when: deploy_portworx_storage|bool
+
+  - name: Change medium worker size
+    replace:
+      path: openshift.yaml
+      regexp: 'ocp.m1.large # add-portworx.yaml replaces this with pwx.m1.medium'
       replace: 'pwx.m1.medium'
+      backup: yes
+    when: deploy_portworx_storage|bool
+
+  - name: Change large worker size
+    replace:
+      path: openshift.yaml
+      regexp: 'ocp.r1.large # add-portworx.yaml replaces this with pwx.r1.large'
+      replace: 'pwx.r1.large'
       backup: yes
     when: deploy_portworx_storage|bool

--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -9,13 +9,6 @@
 # We make a copy of each yaml file that is modified - 
 # ... the *_pwx.yaml files are in gitignore.
 #
-#+create extra networks and outputs in network.yaml
-#pass output from extra networks to all node stacks
-#pass need for extra storage to all nodes stacks
-#pass networks and storage to all nodes
-#if node != infra
-#  add networks to node
-#  add storage to node
 
 # Create copies of files to be changed
   - name: create portworx network file
@@ -35,19 +28,6 @@
       src: ./server_atomic.yaml
       dest: ./server_atomic_pwx.yaml
     when: deploy_portworx_storage|bool
-
-    #  - name: add top-level-template parameters
-    #    blockinfile:
-    #      dest: openshift.yaml
-    #      backup: yes
-    #      insertbefore: "resources:"
-    #      marker: "  # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters"
-    #      block: |2
-    #          deploy_portworx_storage:
-    #            type: boolean
-    #            description: adds volumes and extra networks to non-infra nodes to facilitate portworx deployment
-    #            default: false
-    #when: deploy_portworx_storage|bool
 
 # Replace references to point to copied files
   - name: specify pwx network template
@@ -80,7 +60,6 @@
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      #insertafter: "allocation_pools:"
       insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
       marker: "        # ANSIBLE MANAGED BLOCK - parameters for portworx deployment"
       block: |2
@@ -92,7 +71,6 @@
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      #insertafter: "purpose_ident: tenant-{{ item }}"
       insertafter: "# add-portworx.yaml inserts {{ item }} tenant worker storage networks here"
       marker: "        # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters - worker-{{ item }}"
       block: |2
@@ -106,7 +84,6 @@
     blockinfile:
       dest: openshift.yaml
       backup: yes
-      #insertafter: "purpose_ident: {{ purpose_ident }}-{{ item }}"
       insertafter: "# add-portworx.yaml inserts {{ item }} net2 worker storage networks here"
       marker: "        # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters Net2 - {{ purpose_ident }}-{{ item }}"
       block: |2
@@ -145,7 +122,6 @@
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      #insertbefore: "resources:"
       insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portworx_networks_parameters"
       block: |2
@@ -158,7 +134,6 @@
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      #insertbefore: "outputs:"
       insertafter: "# add-portworx.yaml inserts storage_networks resources here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portworx_networks_resources"
       block: |2
@@ -202,24 +177,10 @@
             get_param: deploy_storage_networks
     when: deploy_portworx_storage|bool
 
-    #  - name: add storage networks
-    #    blockinfile:
-    #      dest: network_pwx.yaml
-    #      backup: yes
-    #      insertbefore: "outputs:"
-    #      marker: "# ANSIBLE MANAGED BLOCK - add_portworx_networks_conditions"
-    #      block: |2
-    #        conditions:
-    #          deploy_storage_networks:
-    #            get_param: deploy_storage_networks
-    #      
-    #    when: deploy_portworx_storage|bool
-
   - name: add storage networks outputs
     blockinfile:
       dest: network_pwx.yaml
       backup: yes
-      #insertafter: "outputs:"
       insertafter: "# add-portworx.yaml inserts storage_networks outputs here"
       marker: "  # ANSIBLE MANAGED BLOCK - add_portwox_networks_outputs"
       block: |2
@@ -236,7 +197,6 @@
     blockinfile:
       dest: node_group_pwx.yaml
       backup: yes
-      #insertbefore: "resources:"
       insertafter: "# add-portworx.yaml inserts network and volume parameters here"
       marker: "  # ANSIBLE MANAGED BLOCK - add parameters to node_group_pwx.yaml"
       block: |2
@@ -256,7 +216,6 @@
     blockinfile:
       dest: node_group_pwx.yaml
       backup: yes
-      #insertafter: "server_group: { get_param: server_group }"
       insertafter: "# add-portworx.yaml inserts server group parameters here"
       marker: "          # ANSIBLE MANAGED BLOCK - add properties to node_group server resources"
       block: |2
@@ -271,7 +230,6 @@
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      #insertbefore: "resources:"
       insertafter: "# add-portworx.yaml inserts atomic network and volume parameters here"
       marker: "  # ANSIBLE MANAGED BLOCK - add parameters to server_atomic_pwx.yaml"
       block: |2
@@ -291,7 +249,6 @@
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      #insertafter: "- port: { get_resource: port }"
       insertafter: "# add-portworx.yaml inserts server_atomic network resources here"
       marker: "        # ANSIBLE MANAGED BLOCK - add properties to server_atomic resources"
       block: |2
@@ -303,7 +260,6 @@
     blockinfile:
       dest: server_atomic_pwx.yaml
       backup: yes
-      #insertbefore: "outputs:"
       insertafter: "# add-portworx.yaml inserts server_atomic volumes here"
       marker: "  # ANSIBLE MANAGED BLOCK - add properties to server_atomic resources"
       block: |2
@@ -378,27 +334,4 @@
                      sudo umount $EPHDEV; sudo wipefs -af $EPHDEV
                      grep -v "${EPHDEV}" /etc/fstab > /tmp/fstab; sudo mv /tmp/fstab /etc/fstab
     when: deploy_portworx_storage|bool
-
-    #  - name: server_atomic storage resources
-    #    blockinfile:
-    #      dest: server_atomic_pwx.yaml
-    #      backup: yes
-    #      insertbefore: "outputs:"
-    #      marker: "# ANSIBLE MANAGED BLOCK - add properties to server_atomic conditions"
-    #      block: |2
-    #        conditions:
-    #          not_infra:
-    #            not:
-    #              equals:
-    #              - get_param: purpose_ident
-    #              - infra
-    #          deploy_volumes:
-    #            equals:
-    #            - get_param: extra_volumes
-    #            - true
-    #          deploy_extra_volumes:
-    #            and:
-    #            - not_infra
-    #            - deploy_volumes
-    #    when: deploy_portworx_storage|bool
 

--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -1,8 +1,14 @@
 - hosts: localhost
   vars:
-    deploy_portworx_storage: "false"
+    deploy_portworx_storage: false
   tasks:
-
+# This inserts the parameters and resources necessary for portworx
+# It searchs for comments in the base files which reference
+# add-portworx.yaml
+#
+# We make a copy of each yaml file that is modified - 
+# ... the *_pwx.yaml files are in gitignore.
+#
 #+create extra networks and outputs in network.yaml
 #pass output from extra networks to all node stacks
 #pass need for extra storage to all nodes stacks
@@ -11,6 +17,7 @@
 #  add networks to node
 #  add storage to node
 
+# Create copies of files to be changed
   - name: create portworx network file
     copy:
       src: ./network.yaml
@@ -42,18 +49,7 @@
     #            default: false
     #when: deploy_portworx_storage|bool
 
-  - name: add parameters to network stack
-    blockinfile:
-      dest: openshift.yaml
-      backup: yes
-      #insertafter: "allocation_pools:"
-      insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
-      marker: "        # ANSIBLE MANAGED BLOCK - parameters for portworx deployment"
-      block: |2
-                # deploy portworx?
-                deploy_storage_networks: { get_param: deploy_portworx_storage }
-    when: deploy_portworx_storage|bool
-
+# Replace references to point to copied files
   - name: specify pwx network template
     replace:
       path: openshift.yaml
@@ -69,6 +65,27 @@
       replace: 'node_group_pwx'
       after: '  worker_small_nodes_deployment'
       backup: yes
+    when: deploy_portworx_storage|bool
+
+  - name: specify pwx server_atomic template
+    replace:
+      path: node_group_pwx.yaml
+      regexp: 'server_atomic.yaml'
+      replace: 'server_atomic_pwx.yaml'
+      backup: yes
+    when: deploy_portworx_storage|bool
+
+# Make edits in openshift.yaml
+  - name: add parameters to network stack
+    blockinfile:
+      dest: openshift.yaml
+      backup: yes
+      #insertafter: "allocation_pools:"
+      insertafter: "# add-portworx.yaml inserts deploy_storage_networks parameter here"
+      marker: "        # ANSIBLE MANAGED BLOCK - parameters for portworx deployment"
+      block: |2
+                # deploy portworx?
+                deploy_storage_networks: { get_param: deploy_portworx_storage }
     when: deploy_portworx_storage|bool
 
   - name: add storage networks parameters
@@ -99,14 +116,31 @@
     loop: [ small, medium, large ]
     when: deploy_portworx_storage|bool and multinetwork|bool
 
-  - name: specify pwx server_atomic template
+    #  - name: Change small worker size
+    #    replace:
+    #      path: openshift.yaml
+    #      regexp: 'ocp.t1.xxlarge # add-portworx.yaml replaces this with pwx.t1.xxlarge'
+    #      replace: 'pwx.t1.xxlarge'
+    #      backup: yes
+    #    when: deploy_portworx_storage|bool
+
+  - name: Change medium worker size
     replace:
-      path: node_group_pwx.yaml
-      regexp: 'server_atomic.yaml'
-      replace: 'server_atomic_pwx.yaml'
+      path: openshift.yaml
+      regexp: 'ocp.m1.large # add-portworx.yaml replaces this with pwx.m1.medium'
+      replace: 'pwx.m1.medium'
       backup: yes
     when: deploy_portworx_storage|bool
 
+    #  - name: Change large worker size
+    #    replace:
+    #      path: openshift.yaml
+    #      regexp: 'ocp.r1.large # add-portworx.yaml replaces this with pwx.r1.large'
+    #      replace: 'pwx.r1.large'
+    #      backup: yes
+    #    when: deploy_portworx_storage|bool
+
+# Make edits in network_pwx.yaml
   - name: add storage networks parameters
     blockinfile:
       dest: network_pwx.yaml
@@ -197,6 +231,7 @@
             condition: deploy_storage_networks
     when: deploy_portworx_storage|bool
 
+# Make edits in node_group_pwx.yaml
   - name: node_group_parameters
     blockinfile:
       dest: node_group_pwx.yaml
@@ -231,6 +266,7 @@
 
     when: deploy_portworx_storage|bool
 
+# Make changes in server_atomic_pwx.yaml
   - name: server_atomic parameters
     blockinfile:
       dest: server_atomic_pwx.yaml
@@ -308,6 +344,18 @@
             - deploy_volumes
     when: deploy_portworx_storage|bool
 
+  - name: server_atomic - add code to wipe ephemeral disk
+    blockinfile:
+      dest: server_atomic_pwx.yaml
+      backup: yes
+      insertafter: "# add-portworx.yaml inserts extra code to wipe ephemeral disk here"
+      marker: "             # ANSIBLE MANAGED BLOCK - add code to wipe ephemeral disk"
+      block: |2
+                     EPHDEV="/dev/"`lsblk | grep /var/mnt | awk '{print $1}'`
+                     sudo umount $EPHDEV; sudo wipefs -af $EPHDEV
+                     grep -v "${EPHDEV}" /etc/fstab > /tmp/fstab; sudo mv /tmp/fstab /etc/fstab
+    when: deploy_portworx_storage|bool
+
     #  - name: server_atomic storage resources
     #    blockinfile:
     #      dest: server_atomic_pwx.yaml
@@ -331,26 +379,3 @@
     #            - deploy_volumes
     #    when: deploy_portworx_storage|bool
 
-  - name: Change small worker size
-    replace:
-      path: openshift.yaml
-      regexp: 'ocp.t1.xxlarge # add-portworx.yaml replaces this with pwx.t1.xxlarge'
-      replace: 'pwx.t1.xxlarge'
-      backup: yes
-    when: deploy_portworx_storage|bool
-
-  - name: Change medium worker size
-    replace:
-      path: openshift.yaml
-      regexp: 'ocp.m1.large # add-portworx.yaml replaces this with pwx.m1.medium'
-      replace: 'pwx.m1.medium'
-      backup: yes
-    when: deploy_portworx_storage|bool
-
-  - name: Change large worker size
-    replace:
-      path: openshift.yaml
-      regexp: 'ocp.r1.large # add-portworx.yaml replaces this with pwx.r1.large'
-      replace: 'pwx.r1.large'
-      backup: yes
-    when: deploy_portworx_storage|bool

--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -311,10 +311,10 @@
             type: OS::Cinder::Volume
             condition: deploy_extra_volumes
             properties:
-              description: Volume for data
+              description: Volume for kvdb
               name:
                 str_replace:
-                  template: vol_data_servername_1
+                  template: vol_kvdb_servername_1
                   params:
                     servername: { get_param: server_name }
               size: 100
@@ -328,6 +328,29 @@
               instance_uuid: { get_resource: server }
               mountpoint: /dev/vdc
               volume_id: { get_resource: portworx_vol1 }
+
+          portworx_vol2:
+            type: OS::Cinder::Volume
+            condition: deploy_extra_volumes
+            properties:
+              description: Volume for data
+              name:
+                str_replace:
+                  template: vol_data_servername_1
+                  params:
+                    servername: { get_param: server_name }
+              size: 100
+              volume_type: TIER2
+
+          vol_attachment_vol2:
+            type: OS::Cinder::VolumeAttachment
+            depends_on: [ server, portworx_vol2, vol_attachment_vol1 ]
+            condition: deploy_extra_volumes
+            properties:
+              instance_uuid: { get_resource: server }
+              mountpoint: /dev/vdd
+              volume_id: { get_resource: portworx_vol2 }
+
         conditions:
           not_infra:
             not:

--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -330,7 +330,7 @@
       insertafter: "# add-portworx.yaml inserts extra code to wipe ephemeral disk here"
       marker: "             # ANSIBLE MANAGED BLOCK - add code to wipe ephemeral disk"
       block: |2
-                     EPHDEV="/dev/"`lsblk | grep /var/mnt | awk '{print $1}'`
+                     EPHDEV="/dev/"`lsblk | grep /var/mnt | awk '{print $1}' | sed 's/[^a-z]*//g'`
                      sudo umount $EPHDEV; sudo wipefs -af $EPHDEV
                      grep -v "${EPHDEV}" /etc/fstab > /tmp/fstab; sudo mv /tmp/fstab /etc/fstab
     when: deploy_portworx_storage|bool

--- a/add-portworx.yaml
+++ b/add-portworx.yaml
@@ -331,7 +331,7 @@
       marker: "             # ANSIBLE MANAGED BLOCK - add code to wipe ephemeral disk"
       block: |2
                      EPHDEV="/dev/"`lsblk | grep /var/mnt | awk '{print $1}' | sed 's/[^a-z]*//g'`
-                     sudo umount $EPHDEV; sudo wipefs -af $EPHDEV
+                     sudo umount /mnt; sudo wipefs -af $EPHDEV
                      grep -v "${EPHDEV}" /etc/fstab > /tmp/fstab; sudo mv /tmp/fstab /etc/fstab
     when: deploy_portworx_storage|bool
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,8 +22,9 @@ if [[ $multinetwork == true ]]; then
      tr '[:upper:]' '[:lower:]')
 fi
 
-deploy_portworx_storage=$(python -c "import yaml;d=yaml.load(open('environment.yaml'));print(d['parameter_defaults']['deploy_portworx_storage'])" |
-   tr '[:upper:]' '[:lower:]')
+deploy_portworx_storage=$(python -c "import yaml;d=yaml.load(open('environment.yaml')); print(d['parameter_defaults']['deploy_portworx_storage'] if d['parameter_defaults'].has_key('deploy_portworx_storage') else 'False')" |
+     tr '[:upper:]' '[:lower:]')
+   
 
 function validateSetup() {
   if [[ -z ${OS_TENANT_ID} ]]; then

--- a/environment_example.yaml
+++ b/environment_example.yaml
@@ -77,4 +77,4 @@ parameter_defaults:
   #  registry_url: "<registry_url>"
   #  registry_user: "<registry_user>"
   #  registry_password: "<registry_password>"
-  #deploy_extra_volumes: <whether to deploy extra volumes to non-infra nodes for portworx>
+  #deploy_portworx_storage: <whether to deploy extra volumes, network and prereqs for portworx>

--- a/network.yaml
+++ b/network.yaml
@@ -20,6 +20,7 @@ parameters:
     type: string
     description: gateway of the network
     default: "10.2.1.254"
+# add-portworx.yaml inserts deploy_storage_networks parameter here
 
 resources:
   InternetGW:
@@ -50,7 +51,9 @@ resources:
       gateway_ip: { get_param: gateway }
       ip_version: 4
 
+# add-portworx.yaml inserts storage_networks resources here
 outputs:
+# add-portworx.yaml inserts storage_networks outputs here    
   network: 
     value: { get_resource: network }
   subnet:

--- a/node_group.yaml
+++ b/node_group.yaml
@@ -69,6 +69,7 @@ parameters:
       GROWPART=true
       ROOT_SIZE=20G
       DATA_SIZE=70G
+# add-portworx.yaml inserts network and volume parameters here
 
 resources:
 
@@ -98,7 +99,7 @@ resources:
           storage_setup: { get_param: storage_setup }
           external_service_subnet: { get_param: external_service_subnet }
           server_group: { get_param: server_group }
-
+          # add-portworx.yaml inserts server group parameters here
 outputs:
   node_list:
     description: host file contents

--- a/server_atomic.yaml
+++ b/server_atomic.yaml
@@ -53,6 +53,7 @@ parameters:
   external_service_subnet:
     type: string
     description: Subnet to be used for external services
+  # add-portworx.yaml inserts atomic network and volume parameters here
 
 resources:
   resize_lv:
@@ -105,6 +106,7 @@ resources:
       key_name: { get_param: key_name }
       networks:
         - port: { get_resource: port }
+        # add-portworx.yaml inserts server_atomic network resources here    
       scheduler_hints:
         group: { get_param: server_group }
       user_data_format: SOFTWARE_CONFIG
@@ -121,6 +123,7 @@ resources:
       network: { get_param: port_network }
       security_groups: { get_param: sec_groups }
       allowed_address_pairs: [ ip_address: { get_param: external_service_subnet } ]
+      # add-portworx.yaml inserts server_atomic volumes here
 
 outputs:
   server_ip:

--- a/server_atomic.yaml
+++ b/server_atomic.yaml
@@ -77,7 +77,7 @@ resources:
             __satellite_fqdn__: { get_param: satellite_fqdn }
             __satellite_deploy__: { get_param: satellite_deploy }                  
           template: |
-            #!/bin/bash -x
+             #!/bin/bash -x
              cd /home/cloud-user
              if [[ "__satellite_deploy__" = True ]] 
              then
@@ -89,6 +89,7 @@ resources:
              subscription-manager repos --disable=*
              subscription-manager repos --enable=rhel-7-server-rpms
              ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+             # add-portworx.yaml inserts extra code to wipe ephemeral disk here
 
   server_init:
     type: OS::Heat::MultipartMime

--- a/setup-heat-templates.yaml
+++ b/setup-heat-templates.yaml
@@ -141,10 +141,11 @@
               template: { get_file: node_group.yaml }
               parameters:
                 node_type: worker
-                node_flavor: ocp.t1.xxlarge
+                node_flavor: ocp.t1.xxlarge # add-portworx.yaml replaces this with pwx.t1.xxlarge
                 key_name: { get_param: key_name }
                 node_scale: { get_param: net2_worker_small_scale }
                 purpose_ident: {{ purpose_ident }}-s
+                # add-portworx.yaml inserts small net2 worker storage networks here
                 local_domain_suffix: { get_param: local_domain_suffix }
                 internal_network: { get_attr: [internal_network, outputs, network] }
                 internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }
@@ -167,10 +168,11 @@
               template: { get_file: node_group.yaml }
               parameters:
                 node_type: worker
-                node_flavor: ocp.m1.large
+                node_flavor: ocp.m1.large # add-portworx.yaml replaces this with pwx.m1.medium
                 key_name: { get_param: key_name }
                 node_scale: { get_param: net2_worker_medium_scale }
                 purpose_ident: {{ purpose_ident }}-m
+                # add-portworx.yaml inserts medium net2 worker storage networks here
                 local_domain_suffix: { get_param: local_domain_suffix }
                 internal_network: { get_attr: [internal_network, outputs, network] }
                 internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }
@@ -193,10 +195,11 @@
               template: { get_file: node_group.yaml }
               parameters:
                 node_type: worker
-                node_flavor: ocp.r1.large
+                node_flavor: ocp.r1.large # add-portworx.yaml replaces this with pwx.r1.large
                 key_name: { get_param: key_name }
                 node_scale: { get_param: net2_worker_large_scale }
                 purpose_ident: {{ purpose_ident }}-l
+                # add-portworx.yaml inserts large net2 worker storage networks here
                 local_domain_suffix: { get_param: local_domain_suffix }
                 internal_network: { get_attr: [internal_network, outputs, network] }
                 internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -169,6 +169,7 @@ resources:
       template: { get_file: network.yaml }
       parameters:
         allocation_pools: { get_param: [ network_config, allocation_pool ] }
+        # add-portworx.yaml inserts deploy_storage_networks parameter here
         cidr: { get_param: [ network_config, cidr ] }
         dns: { get_param: [ network_config, dns ] }
         external_network: { get_param: external_network_cp }
@@ -296,10 +297,11 @@ resources:
       template: { get_file: node_group.yaml }
       parameters:
         node_type: worker
-        node_flavor: ocp.t1.xxlarge
+        node_flavor: ocp.t1.xxlarge # add-portworx.yaml replaces this with pwx.t1.xxlarge
         key_name: { get_param: key_name }
         node_scale: { get_param: worker_small_scale }
         purpose_ident: tenant-s
+        # add-portworx.yaml inserts small tenant worker storage networks here
         local_domain_suffix: { get_param: local_domain_suffix }
         internal_network: { get_attr: [internal_network, outputs, network] }
         internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }
@@ -322,10 +324,11 @@ resources:
       template: { get_file: node_group.yaml }
       parameters:
         node_type: worker
-        node_flavor: pwx.m1.medium
+        node_flavor: ocp.m1.large # add-portworx.yaml replaces this with pwx.m1.medium
         key_name: { get_param: key_name }
         node_scale: { get_param: worker_medium_scale }
         purpose_ident: tenant-m
+        # add-portworx.yaml inserts medium tenant worker storage networks here
         local_domain_suffix: { get_param: local_domain_suffix }
         internal_network: { get_attr: [internal_network, outputs, network] }
         internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }
@@ -348,10 +351,11 @@ resources:
       template: { get_file: node_group.yaml }
       parameters:
         node_type: worker
-        node_flavor: ocp.r1.large
+        node_flavor: ocp.r1.large # add-portworx.yaml replaces this with pwx.r1.large
         key_name: { get_param: key_name }
         node_scale: { get_param: worker_large_scale }
         purpose_ident: tenant-l
+        # add-portworx.yaml inserts large tenant worker storage networks here
         local_domain_suffix: { get_param: local_domain_suffix }
         internal_network: { get_attr: [internal_network, outputs, network] }
         internal_network_subnet: { get_attr: [internal_network, outputs, subnet] }


### PR DESCRIPTION
- Portworx additions are controlled by deploy_portworx_storage bool parameter in environment.yaml
- Added comments in the main yaml files which set where add-portworx.yaml targets
- Changed the order of operations in add-portworx.yaml
- Added automatic wiping of ephemeral volume
- Added kvdb cinder volume
- deploy_portworx_storage bool parameter is added to the all,yml inventory file on bastion for use by openshift-deployment-ansible

NOTE: code relating to small and large portworx flavors is currently commented out since flavors aren't created