### PR TITLE
added parameter to choose ansible branch

### DIFF
--- a/bastion-template.yaml
+++ b/bastion-template.yaml
@@ -163,6 +163,9 @@ parameters:
     type: json
     description: Configuration needed for authenticated container registry
     hidden: true
+  ansible_branch:
+    type: string
+    description: Ansible branch that is pulled on bastion deployment.
 
 resources:
   bastion_port:
@@ -284,6 +287,7 @@ resources:
             __registry_url__ : { get_param: [ registry_details, registry_url ] }
             __registry_user__: { get_param: [ registry_details, registry_user ] }
             __registry_password__ : { get_param: [ registry_details, registry_password ] }
+            __ansible_branch__ : { get_param: ansible_branch }
           template: { get_file: 'files/setup_bastion.yaml' }
       outputs:
       - name: result

--- a/environment_example.yaml
+++ b/environment_example.yaml
@@ -77,3 +77,4 @@ parameter_defaults:
   #  registry_url: "<registry_url>"
   #  registry_user: "<registry_user>"
   #  registry_password: "<registry_password>"
+  ansible_branch: "v3.11"

--- a/files/setup_bastion.yaml
+++ b/files/setup_bastion.yaml
@@ -54,6 +54,7 @@
     registryUrl: __registry_url__
     registryUser: __registry_user__
     registryPassword: __registry_password__
+    ansibleBranch: __ansible_branch__
 
   tasks:
     - name: Check if stack update or create and register variable
@@ -277,7 +278,7 @@
       git:
         repo: 'https://github.com/UKCloud/openshift-deployment-ansible.git'
         dest: /usr/share/ansible/openshift-deployment-ansible
-        version: master
+        version: "{{ ansibleBranch }}"
       when: stack_create
 
     - name: Create variables symlink

--- a/top-level-template.yaml
+++ b/top-level-template.yaml
@@ -157,6 +157,10 @@ parameters:
       registry_url: "<registry_url>"
       registry_user: "<registry_user>"
       registry_password: "<registry_password>"
+  ansible_branch:
+    type: string
+    description: Ansible branch that will be pulled on bastion deployment.
+    default: master
 
 
 resources:
@@ -438,6 +442,7 @@ resources:
         sso_config: { get_param: sso_config }
         external_service_subnet: { get_param: [ network_config, service_subnet ] }
         registry_details: { get_param: registry_details }
+        ansible_branch: {get_param: ansible_branch }
 
 
 conditions:


### PR DESCRIPTION
ansible_branch parameter can be added to pull specific ansible branches on heat deployment. If not specified defaults to master. If non-existent branch specified bastion deployment step fails.