### PR TITLE
Add satellite-tools 6.5 and fix Bastion subscription

### DIFF
--- a/files/install_config_agent_yum.sh
+++ b/files/install_config_agent_yum.sh
@@ -33,7 +33,7 @@ retry subscription-manager register --org __rhn_orgid__ --activationkey __rhn_ac
 # install katello agent from specific repo and then disable
 if [[ "__satellite_deploy__" = True ]]
 then
-        subscription-manager repos --enable=rhel-7-server-satellite-tools-6.3-rpms
+        subscription-manager repos --enable=rhel-7-server-satellite-tools-6.5-rpms
         yum install -y katello-agent
 fi
 
@@ -54,7 +54,7 @@ retry subscription-manager repos \
         --enable=rhel-7-server-openstack-12-tools-rpms \
         --enable=rhel-7-server-rh-common-rpms \
         --enable=rhel-7-server-ansible-2.6-rpms \
-        --enable=rhel-7-server-satellite-tools-6.3-rpms
+        --enable=rhel-7-server-satellite-tools-6.5-rpms
 
 retry yum install -y \
         os-collect-config \

--- a/server_with_port.yaml
+++ b/server_with_port.yaml
@@ -74,7 +74,7 @@ resources:
              subscription-manager repos --enable=rhel-7-server-rpms 
              if [[ "__satellite_deploy__" = True ]] 
              then
-             	subscription-manager repos --enable=rhel-7-server-satellite-tools-6.3-rpms
+             	subscription-manager repos --enable=rhel-7-server-satellite-tools-6.5-rpms
              	yum install -y katello-agent
              fi
              systemctl enable rhsmcertd --now


### PR DESCRIPTION
Tested using "latest" activation key (having added required repository to most recent content view version). This shouldn't be merged to v3.11 until all activation keys have been promoted to a content view version which includes the "Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64" repository