### PR TITLE
Change method of determining Pool Id due to Satellite upgrade

### DIFF
--- a/files/install_config_agent_yum.sh
+++ b/files/install_config_agent_yum.sh
@@ -38,8 +38,8 @@ then
 fi
 
 # determine pool ID's for red hat subscriptions
-openstackPoolId=$(retry subscription-manager list --available | grep 'Red Hat OpenStack Platform for Service Providers' -A100 | grep -m 1 'Pool ID' | awk '{print $NF}')
-openshiftPoolId=$(retry subscription-manager list --available | grep 'Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' -A100 | grep -m 1 'Pool ID' | awk '{print $NF}')
+openstackPoolId=$(subscription-manager list --available --matches='Red Hat OpenStack Platform for Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
+openshiftPoolId=$(subscription-manager list --available --matches='Red Hat OpenShift Container Platform for Certified Cloud and Service Providers' | awk '/System Type:\s*Physical/' RS='\n\n' | awk '/Pool ID/ {print $NF}')
 
 # setup repos & install software packages
 retry subscription-manager attach --pool=$openstackPoolId


### PR DESCRIPTION
Removed from 6.5-satellite-tools branch so v3.11 deployments can be fixed without requiring environments to be promoted to latest content view version